### PR TITLE
Parameterize container demand

### DIFF
--- a/ADHDataView/DESCRIPTION
+++ b/ADHDataView/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ADHDataView
 Type: Package
 Title: Provide Shaped Data from ADH
-Version: 1.2.1
+Version: 1.2.3
 Author: OSIsoft LLC
 Maintainer: OSISoft Samples <samples@aveva.com>
 Description: This package is a very simple client library that connects

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 1.2.3 / 2022-06-13
+
+- Parameterized pipeline container demands
+
 ## 1.2.2 / 2022-03-22
 
 - Changed agent used in pipeline

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub. The samples also work on OSIsoft Cloud Services unless otherwise noted. |
 | -----------------------------------------------------------------------------------------------|  
 
-**Version:** 1.2.2
+**Version:** 1.2.3
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/aveva.sample-adh-data_views_r-r?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=3168&branchName=main)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,12 +45,15 @@ variables:
   - name: analysisProject
     value: Data_Views_R
 
+parameters:
+  - name: containerDemands
+    default: R
+
 jobs:
   - job: Tests
     pool:
       name: 00-OSIManaged-Build
-      demands: 
-      - R -equals 4.1.3
+      demands: ${{ parameters.containerDemands }}
     steps:
       - template: '/miscellaneous/build_templates/config.yml@templates'
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ variables:
 
 parameters:
   - name: containerDemands
-    default: R
+    default: R -gVersion 4.1.3
 
 jobs:
   - job: Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ variables:
 
 parameters:
   - name: containerDemands
-    default: R -gVersion 4.1.3
+    default: R -gtVersion 4.1.3
 
 jobs:
   - job: Tests


### PR DESCRIPTION
Parameterized the container demands, and removed the version number from the demand. [Demands can only demand the existence of a particular software, or an exact version match](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/demands?view=azure-devops&tabs=yaml).
![image](https://user-images.githubusercontent.com/73293551/173435091-fd857cb5-40a6-4168-ac03-6442e2219939.png)

Since there's no way to match on an R version of ^x.y.z, keeping this version specific will continue to fail over time as the container images are upgraded; I would not consider these valid failures, so I'd like to remove the version check entirely. If the container happens to have too old of an R version somehow, then it will fail the pipeline, and we can temporarily demand a specific (later) version through the ADO portal's pipeline parameters until the container images with older versions are all updated.